### PR TITLE
Improve EOF error messages on schema validation

### DIFF
--- a/openMINDS_validation/utils.py
+++ b/openMINDS_validation/utils.py
@@ -43,17 +43,13 @@ def check_newline_end_of_file(file_path):
         f.seek(0, 2)
         file_size = f.tell()
 
-        if file_size == 0:
-            logging.error(f'Unexpected file ending for "{file_path}": file is empty.')
+        if file_size < 2:
+            logging.error(f'File is too short to be a valid JSON file: "{file_path}".')
             return
 
         f.seek(-1, 2)
         if f.read(1) != b'\n':
             logging.error(f'No newline at end of file "{file_path}".')
-            return
-
-        if file_size < 2:
-            logging.error(f'File should end with a closing }} followed by a single newline: "{file_path}".')
             return
 
         f.seek(-2, 2)

--- a/openMINDS_validation/utils.py
+++ b/openMINDS_validation/utils.py
@@ -40,9 +40,25 @@ class Versions:
 
 def check_newline_end_of_file(file_path):
     with open(file_path, 'rb') as f:
-        f.seek(-2, 2)
-        if f.read(2) != b'}\n':
+        f.seek(0, 2)
+        file_size = f.tell()
+
+        if file_size == 0:
+            logging.error(f'Unexpected file ending for "{file_path}": file is empty.')
+            return
+
+        f.seek(-1, 2)
+        if f.read(1) != b'\n':
             logging.error(f'No newline at end of file "{file_path}".')
+            return
+
+        if file_size < 2:
+            logging.error(f'File should end with a closing }} followed by a single newline: "{file_path}".')
+            return
+
+        f.seek(-2, 2)
+        if f.read(1) != b'}':
+            logging.error(f'File should end with a closing }} followed by a single newline: "{file_path}".')
 
 def load_json(file_path):
     check_newline_end_of_file(file_path)


### PR DESCRIPTION
## What changed

Improved the end-of-file validation messages in `openMINDS_validation/utils.py` by:
- short file check so files under 2 bytes fail with a more accurate message
- added a clearer message for files that do not end with a closing `}` followed by a single newline

## Why

The previous EOF check could report misleading errors for some invalid file endings. For example, when validating a file with 2 newline characters at the end of the file, the error would state: `No newline at end of file`

## Impact

Schema validation failures caused by invalid file endings should now be easier to understand and fix.

## Validation

- parsed `openMINDS_validation/utils.py` successfully with `ast.parse`
- did not run the full validator flow