### PR TITLE
Improve download error failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+versions.json

--- a/openMINDS_validation/utils.py
+++ b/openMINDS_validation/utils.py
@@ -4,6 +4,7 @@ import os
 import re
 import shutil
 import json
+import ssl
 import urllib.request
 import urllib.error
 
@@ -18,6 +19,10 @@ logging.basicConfig(
 )
 
 _remote_schema_cache = {}
+
+
+class DownloadError(RuntimeError):
+    pass
 
 class VocabManager:
     def __init__(self, path_vocab_types, path_vocab_properties):
@@ -50,11 +55,23 @@ def load_json(file_path):
         json_file = json.load(f)
     return json_file
 
+def _format_download_error(url, path, error):
+    if isinstance(error, urllib.error.URLError) and isinstance(error.reason, ssl.SSLCertVerificationError):
+        reason = "SSL certificate verification failed. Check your local Python certificate store."
+    else:
+        reason = str(error)
+    return f'Failed to download "{url}" to "{path}": {reason}'
+
 def download_file(url, path):
     try:
         urllib.request.urlretrieve(url, path)
     except (urllib.error.URLError, IOError) as e:
-        logging.error(e)
+        has_local_fallback = os.path.exists(path) and os.path.getsize(path) > 0
+        message = _format_download_error(url, path, e)
+        if has_local_fallback:
+            logging.warning(f"{message} Using existing local file instead.")
+            return
+        raise DownloadError(message) from e
 
 def clone_central(refetch:bool=False):
     if refetch and os.path.exists("sources"):


### PR DESCRIPTION
## What changed

- improve error handling when `versions.json` and related metadata downloads fail
- raise a clear `DownloadError` instead of falling through to a later `FileNotFoundError`
- make SSL certificate verification failures report a clearer, more actionable message
- add `versions.json` to `.gitignore` so the downloaded file is not tracked accidentally

## Why

When the validator could not download `versions.json`, it logged a network error and then continued into a confusing `FileNotFoundError` because the file was never created. 

## Impact

Validation failures caused by download problems should now be easier to understand and diagnose, especially for local SSL certificate issues.

## Validation

- parsed `openMINDS_validation/utils.py` successfully with `ast.parse`
- did not run the full validator flow
